### PR TITLE
fix: include sort in sticky section above library items

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -78,20 +78,22 @@
       </fieldset>
     </div>
     <div id="library-container">
-      <label>
-        Filter:
-        <input id="library-filter-input" type="text" />
-      </label>
-      <div id="library-sort-input">
-        Sort:
+      <div class="controls">
         <label>
-          <input name="library-sort-input" type="radio" value="index" checked />
-          by order
+          Filter:
+          <input id="library-filter-input" type="text" />
         </label>
-        <label>
-          <input name="library-sort-input" type="radio" value="title" />
-          by title
-        </label>
+        <div id="library-sort-input">
+          Sort:
+          <label>
+            <input name="library-sort-input" type="radio" value="index" checked />
+            by order
+          </label>
+          <label>
+            <input name="library-sort-input" type="radio" value="title" />
+            by title
+          </label>
+        </div>
       </div>
       <ul>
   

--- a/public/style.css
+++ b/public/style.css
@@ -63,17 +63,20 @@ input {
     overflow: auto;
 }
 
-/* filter controls */
-#library-container > label {
+#library-container > .controls {
+    top: 0;
     background: white;
     width: 100%;
     position: sticky;
-    top: 0;
+}
+
+/* filter controls */
+#library-container > .controls > label {
     display: flex;
     align-items: center;
     gap: .5em;
 }
-#library-container > label > input {
+#library-container > .controls > label > input {
     flex: auto;
 }
 


### PR DESCRIPTION
missed this in the last update since the list wasn't long enough to scroll